### PR TITLE
Remove the warning shown because unarchive is not being used

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   when: resty_tar.stat.exists == False or resty_exe.stat.exists == False
 
 - name: Extract Openresty tarball
-  command: chdir=/tmp/ /bin/tar zxf openresty.tar.gz
+  unarchive: src=/tmp/openresty.tar.gz dest=/tmp/ copy=no
   when: resty_tar.stat.exists == False or resty_exe.stat.exists == False
 
 - name: Build configure command


### PR DESCRIPTION
Removed the following warning:

```
TASK: [Extract Openresty tarball] *************************************
changed: [X.X.X.X]
warning: Consider using unarchive module rather than running tar
```

Now it uses `unarchive` module instead of calling `tar` inside a `command`
