### PR TITLE
Add variable for open resty download url 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for nginx
 openresty_version: 1.7.7.2
+# change to http://openresty.org/download/openresty- for >= 1.9.7.3
+openresty_download_url: http://openresty.org/download/ngx_openresty-
 with_luajit: true
 with_dav: true
 with_flv: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   when: resty_exe.stat.exists == False
 
 - name: Download Openresty source
-  get_url: url=http://openresty.org/download/ngx_openresty-{{ openresty_version }}.tar.gz dest=/tmp/openresty.tar.gz mode=0440
+  get_url: url={{ openresty_download_url }}{{ openresty_version }}.tar.gz dest=/tmp/openresty.tar.gz mode=0440
   when: resty_tar.stat.exists == False or resty_exe.stat.exists == False
 
 - name: Extract Openresty tarball


### PR DESCRIPTION
This is required to support openresty >=1.9.7.3 because they have changed the naming convention.  See:  https://openresty.org/en/download.html
