### PR TITLE
nginx-extra removed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for nginx
-openresty_version: 1.9.15.1
+openresty_version: 1.11.2.5
 openresty_download_url: https://openresty.org/download/openresty-
 with_luajit: true
 with_dav: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,7 @@
 - name: Check if openresty already installed...
   shell: nginx -v
   register: nginx_ver
+  ignore_errors: yes
 
 - name: Update apt
   sudo: yes
@@ -58,11 +59,11 @@
   command: chdir=/tmp/openresty-{{ openresty_version }} make install
   when: nginx_ver.stderr.find(openresty_version) == -1
 
-- name: Service command
-  template: src=service.j2 dest=/etc/init.d/nginx owner=root group=root mode=0777
-  when: nginx_ver.stderr.find(openresty_version) == -1
-
-- name: Putting service in start up
-  command: update-rc.d nginx defaults
-  notify: restart nginx
-  when: nginx_ver.stderr.find(openresty_version) == -1
+- name: Systemd service file
+  template:
+    src: openresty.j2
+    dest: /lib/systemd/system/openresty.service
+    owner: root
+    group: root
+    mode: 0777
+#  when: nginx_ver.stderr.find(openresty_version) == -1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,6 @@
 - name: Install required packages to compile Openresty from source
   apt: name={{ item }}
   with_items:
-    - nginx-extras
     - build-essential
     - libreadline-dev
     - make

--- a/templates/configure_command.j2
+++ b/templates/configure_command.j2
@@ -3,7 +3,6 @@ mkdir /var/lib/nginx
 ./configure \
 --pid-path=/var/run/nginx.pid \
 --lock-path=/var/lock/nginx.lock \
---sbin-path=/usr/sbin/nginx \
 --conf-path=/etc/nginx/nginx.conf \
 --error-log-path=/var/log/nginx/error.log \
 {% if with_luajit %} --with-luajit {% endif %}

--- a/templates/openresty.j2
+++ b/templates/openresty.j2
@@ -1,0 +1,33 @@
+# Stop dance for OpenResty
+# =========================
+#
+# ExecStop sends SIGSTOP (graceful stop) to OpenResty's nginx process.
+# If, after 5s (--retry QUIT/5) nginx is still running, systemd takes control
+# and sends SIGTERM (fast shutdown) to the main process.
+# After another 5s (TimeoutStopSec=5), and if nginx is alive, systemd sends
+# SIGKILL to all the remaining processes in the process group (KillMode=mixed).
+#
+# nginx signals reference doc:
+# http://nginx.org/en/docs/control.html
+#
+[Unit]
+Description=full-fledged web platform
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/tmp/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t -q -g 'daemon on; master_process on;'
+ExecStart=/usr/sbin/nginx -g 'daemon on; master_process on;'
+ExecReload=/usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
+ExecStop=/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /var/run/nginx.pid
+TimeoutStopSec=5
+KillMode=mixed
+Environment=MUMS_PUBLIC=/opt/keys/mothership.pub
+Environment=HUB_PUBLIC=/opt/keys/hub.pub
+Environment=HUB_PRIVATE=/opt/keys/hub.pem
+Environment=HUB_SERIAL={{halley_serial_number}}
+Environment=PAIRING_CODE={{halley_pairing}}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
nginx-extras depends upon nginx-common which is not going to be installed.